### PR TITLE
MolrFxSupport

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import org.gradle.api.JavaVersion
-
 buildscript {
     project.ext['CERN_VM'] = System.getProperty('CERN_TECHNET_VM') ?: System.getenv('CERN_TECHNET_VM') ?: System.getProperty('CERN_VM') ?: System.getenv('CERN_VM') ?: false
     project.ext['DEPLOYMENT'] = System.getProperty('deployment') ?: false

--- a/src/main/java/io/molr/gui/fx/MolrFxSupportFactory.java
+++ b/src/main/java/io/molr/gui/fx/MolrFxSupportFactory.java
@@ -1,0 +1,49 @@
+package io.molr.gui.fx;
+
+import io.molr.gui.fx.conf.MolrFxSupportConfiguration;
+import io.molr.gui.fx.support.MolrFxSupport;
+import org.minifx.workbench.conf.MiniFxWorkbenchConfiguration;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+import java.util.*;
+
+/**
+ * This class is intended for users that want to consistently reject the advantages of spring and thus do not want to
+ * use spring configurations directly in their gui applications ;-) The usage of this is discouraged!
+ * Instead, it is recommended to import the spring {@link MolrFxSupportConfiguration} directly into your own spring
+ * configuration. This way, the {@link MolrFxSupport} can be autowired wherever you need it! ;-)
+ * <p>
+ * Enough of disclaimer ;-) For those who really want, they can use the {@link #newMolrFxSupport(Class[])} to create a
+ * fresh instance, while you have to provide the configuration classes for molr as parameters (e.g. containing moles [and missions if local])
+ */
+public final class MolrFxSupportFactory {
+
+    private MolrFxSupportFactory() {
+        throw new UnsupportedOperationException("only static methods");
+    }
+
+    /**
+     * Creates a new {@link MolrFxSupport} by instantiating an application context and looking up the bean. The
+     * additional configuration classes given as parameters have to provide at least the mole to use. Otherwise,
+     * the context cannot be loaded.
+     *
+     * @param configurationClasses The configuration classes, providing the essentials of molr
+     * @return a fully configured support to use molr-specific gui elements in an elegant way.
+     */
+    public static MolrFxSupport newMolrFxSupport(Class<?>... configurationClasses) {
+        @SuppressWarnings("resource") /* Closed automatically by the hook */
+                AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(ensureSingleFxSupportConfig(configurationClasses));
+
+        /* Spring context register itself in the shutdown hook. It automatically keeps a reference to it this way */
+        ctx.registerShutdownHook();
+
+        return ctx.getBean(MolrFxSupport.class);
+    }
+
+    private static final Class<?>[] ensureSingleFxSupportConfig(Class<?>... configurationClasses) {
+        Set<Class<?>> classes = new HashSet<>(Arrays.asList(configurationClasses));
+        classes.add(MolrFxSupportConfiguration.class);
+        return classes.toArray(new Class<?>[classes.size()]);
+    }
+
+}

--- a/src/main/java/io/molr/gui/fx/MolrFxSupportFactory.java
+++ b/src/main/java/io/molr/gui/fx/MolrFxSupportFactory.java
@@ -2,10 +2,11 @@ package io.molr.gui.fx;
 
 import io.molr.gui.fx.conf.MolrFxSupportConfiguration;
 import io.molr.gui.fx.support.MolrFxSupport;
-import org.minifx.workbench.conf.MiniFxWorkbenchConfiguration;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * This class is intended for users that want to consistently reject the advantages of spring and thus do not want to

--- a/src/main/java/io/molr/gui/fx/MolrFxSupportFactory.java
+++ b/src/main/java/io/molr/gui/fx/MolrFxSupportFactory.java
@@ -9,13 +9,12 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * This class is intended for users that want to consistently reject the advantages of spring and thus do not want to
- * use spring configurations directly in their gui applications ;-) The usage of this is discouraged!
- * Instead, it is recommended to import the spring {@link MolrFxSupportConfiguration} directly into your own spring
- * configuration. This way, the {@link MolrFxSupport} can be autowired wherever you need it! ;-)
+ * This class is intended for cases spring is not used as core of the respective application.
+ * The usage of this is discouraged! Instead, it is recommended to import the spring {@link MolrFxSupportConfiguration} directly into your own spring
+ * configuration. This way, the {@link MolrFxSupport} can be autowired wherever it is needed!
  * <p>
- * Enough of disclaimer ;-) For those who really want, they can use the {@link #newMolrFxSupport(Class[])} to create a
- * fresh instance, while you have to provide the configuration classes for molr as parameters (e.g. containing moles [and missions if local])
+ * The method {@link #newMolrFxSupport(Class[])} creates a fresh instance
+ * fresh instance, while the configuration classes for molr have to be provided as parameters (e.g. containing moles [and missions if local])
  */
 public final class MolrFxSupportFactory {
 

--- a/src/main/java/io/molr/gui/fx/conf/MolrFxSupportConfiguration.java
+++ b/src/main/java/io/molr/gui/fx/conf/MolrFxSupportConfiguration.java
@@ -1,0 +1,20 @@
+package io.molr.gui.fx.conf;
+
+import io.molr.gui.fx.support.MolrFxSupport;
+import io.molr.gui.fx.support.MolrFxSupportImpl;
+import io.molr.mole.core.api.Mole;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MolrFxSupportConfiguration {
+
+    @Autowired
+    private Mole mole;
+
+    @Bean
+    public MolrFxSupport molrFxSupport() {
+        return new MolrFxSupportImpl(mole);
+    }
+}

--- a/src/main/java/io/molr/gui/fx/demo/MolrFxSupportDemoApplication.java
+++ b/src/main/java/io/molr/gui/fx/demo/MolrFxSupportDemoApplication.java
@@ -1,0 +1,40 @@
+package io.molr.gui.fx.demo;
+
+import io.molr.commons.domain.Mission;
+import io.molr.gui.fx.conf.MolrFxSupportConfiguration;
+import io.molr.gui.fx.support.MolrFxSupport;
+import io.molr.gui.fx.support.SimpleMissionControl;
+import io.molr.mole.core.runnable.conf.RunnableLeafMoleConfiguration;
+import io.molr.mole.core.runnable.demo.conf.DemoRunnableLeafsConfiguration;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.layout.VBox;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toList;
+import static org.minifx.fxcommons.SingleSceneSpringJavaFxApplication.applicationLauncher;
+
+@Configuration
+@Import({DemoRunnableLeafsConfiguration.class, RunnableLeafMoleConfiguration.class, MolrFxSupportConfiguration.class})
+public class MolrFxSupportDemoApplication {
+
+    @Autowired
+    private MolrFxSupport support;
+
+    public static void main(String... args) {
+        applicationLauncher().configurationClasses(MolrFxSupportDemoApplication.class).launch();
+    }
+
+    @Bean
+    public Scene mainScene() {
+        return UiCreation.createScene(support);
+    }
+
+
+}

--- a/src/main/java/io/molr/gui/fx/demo/MolrFxSupportDemoApplication.java
+++ b/src/main/java/io/molr/gui/fx/demo/MolrFxSupportDemoApplication.java
@@ -1,23 +1,15 @@
 package io.molr.gui.fx.demo;
 
-import io.molr.commons.domain.Mission;
 import io.molr.gui.fx.conf.MolrFxSupportConfiguration;
 import io.molr.gui.fx.support.MolrFxSupport;
-import io.molr.gui.fx.support.SimpleMissionControl;
 import io.molr.mole.core.runnable.conf.RunnableLeafMoleConfiguration;
 import io.molr.mole.core.runnable.demo.conf.DemoRunnableLeafsConfiguration;
 import javafx.scene.Scene;
-import javafx.scene.control.Button;
-import javafx.scene.layout.VBox;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
-import java.util.List;
-import java.util.Set;
-
-import static java.util.stream.Collectors.toList;
 import static org.minifx.fxcommons.SingleSceneSpringJavaFxApplication.applicationLauncher;
 
 @Configuration

--- a/src/main/java/io/molr/gui/fx/demo/MolrFxSupportMinimalSpringDemo.java
+++ b/src/main/java/io/molr/gui/fx/demo/MolrFxSupportMinimalSpringDemo.java
@@ -1,0 +1,25 @@
+package io.molr.gui.fx.demo;
+
+import io.molr.gui.fx.MolrFxSupportFactory;
+import io.molr.gui.fx.support.MolrFxSupport;
+import io.molr.mole.core.runnable.conf.RunnableLeafMoleConfiguration;
+import io.molr.mole.core.runnable.demo.conf.DemoRunnableLeafsConfiguration;
+import javafx.scene.Scene;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.minifx.fxcommons.SingleSceneSpringJavaFxApplication.applicationLauncher;
+
+@Configuration
+public class MolrFxSupportMinimalSpringDemo {
+
+    public static void main(String... args) {
+        applicationLauncher().configurationClasses(MolrFxSupportMinimalSpringDemo.class).launch();
+    }
+
+    @Bean
+    public Scene mainScene() {
+        MolrFxSupport support = MolrFxSupportFactory.newMolrFxSupport(DemoRunnableLeafsConfiguration.class, RunnableLeafMoleConfiguration.class);
+        return UiCreation.createScene(support);
+    }
+}

--- a/src/main/java/io/molr/gui/fx/demo/UiCreation.java
+++ b/src/main/java/io/molr/gui/fx/demo/UiCreation.java
@@ -1,0 +1,41 @@
+package io.molr.gui.fx.demo;
+
+import io.molr.commons.domain.Mission;
+import io.molr.gui.fx.support.MolrFxSupport;
+import io.molr.gui.fx.support.SimpleMissionControl;
+import javafx.scene.Scene;
+import javafx.scene.control.Button;
+import javafx.scene.layout.VBox;
+
+import java.util.List;
+import java.util.Set;
+
+import static java.util.stream.Collectors.toList;
+
+public final class UiCreation {
+
+    private UiCreation() {
+        /* only static helper methods */
+    }
+
+    public static Scene createScene(MolrFxSupport support) {
+        Set<Mission> missions = support.executableMissions();
+        List<Button> debugButtons = missions.stream().map(m -> {
+            Button button = new Button("debug '" + m.name() + "'");
+            button.setOnAction(e -> support.debug(m).inNewStage());
+            return button;
+        }).collect(toList());
+
+        List<Button> runButtons = missions.stream().map(m -> {
+            Button button = new Button("run '" + m.name() + "'");
+            button.setOnAction(e -> support.debug(m).inNewStage().ifPresent(SimpleMissionControl::resume));
+            return button;
+        }).collect(toList());
+
+
+        VBox root = new VBox();
+        root.getChildren().addAll(debugButtons);
+        root.getChildren().addAll(runButtons);
+        return new Scene(root);
+    }
+}

--- a/src/main/java/io/molr/gui/fx/demo/UiCreation.java
+++ b/src/main/java/io/molr/gui/fx/demo/UiCreation.java
@@ -1,8 +1,11 @@
 package io.molr.gui.fx.demo;
 
+import com.google.common.collect.ImmutableList;
 import io.molr.commons.domain.Mission;
 import io.molr.gui.fx.support.MolrFxSupport;
 import io.molr.gui.fx.support.SimpleMissionControl;
+import io.molr.mole.core.support.domain.VoidStub1;
+import io.molr.mole.core.support.domain.VoidStub3;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.layout.VBox;
@@ -10,9 +13,21 @@ import javafx.scene.layout.VBox;
 import java.util.List;
 import java.util.Set;
 
+import static io.molr.commons.domain.Placeholder.aString;
+import static io.molr.commons.domain.Placeholder.anInteger;
+import static io.molr.mole.core.support.MissionStubs.stub;
 import static java.util.stream.Collectors.toList;
 
 public final class UiCreation {
+
+    /*
+     * The following are examples of mission stubs: They are useful, in case you know in advance how the parameter
+     * structure of the mission looks like and you want to use the mission from code. This way, the parameters will be
+     * type checked at compile time ;-)
+     */
+    private static VoidStub1<String> CONTEXTUAL_MISSION = stub("contextual mission").withParameters(aString("deviceName"));
+    private static VoidStub3<String, Integer, Integer> PARAMETRIZED_MISSION = stub("Executable Leafs Demo Mission (parametrized)") //
+            .withParameters(aString("aMessage"), anInteger("iterations"), anInteger("sleepMillis"));
 
     private UiCreation() {
         /* only static helper methods */
@@ -20,22 +35,34 @@ public final class UiCreation {
 
     public static Scene createScene(MolrFxSupport support) {
         Set<Mission> missions = support.executableMissions();
-        List<Button> debugButtons = missions.stream().map(m -> {
-            Button button = new Button("debug '" + m.name() + "'");
-            button.setOnAction(e -> support.debug(m).inNewStage());
-            return button;
-        }).collect(toList());
 
-        List<Button> runButtons = missions.stream().map(m -> {
-            Button button = new Button("run '" + m.name() + "'");
-            button.setOnAction(e -> support.debug(m).inNewStage().ifPresent(SimpleMissionControl::resume));
-            return button;
-        }).collect(toList());
+        System.out.println(missions);
 
+        List<Button> debugButtons = missions.stream().map(m ->
+                button("debug '" + m.name() + "'", () -> support.debug(m).inNewStage()))
+                .collect(toList());
+
+        List<Button> runButtons = missions.stream().map(m ->
+                button("run '" + m.name() + "'", () -> support.debug(m).inNewStage().ifPresent(SimpleMissionControl::resume)))
+                .collect(toList());
+
+        List<Button> stubButtons = ImmutableList.of(//
+                button("debug stub1", () -> support.debug(CONTEXTUAL_MISSION, "anyDevice").inNewStage()),//
+                button("run stub1", () -> support.debug(CONTEXTUAL_MISSION, "anotherDevice").inNewStage().ifPresent(SimpleMissionControl::resume)),
+                button("debug stub3", () -> support.debug(PARAMETRIZED_MISSION, "Hello World", 3, 200).inNewStage()),
+                button("run stub3", () -> support.debug(PARAMETRIZED_MISSION, "Hello Molr", 6, 100).inNewStage().ifPresent(SimpleMissionControl::resume))
+        );
 
         VBox root = new VBox();
         root.getChildren().addAll(debugButtons);
         root.getChildren().addAll(runButtons);
+        root.getChildren().addAll(stubButtons);
         return new Scene(root);
+    }
+
+    private static Button button(String text, Runnable action) {
+        Button button = new Button(text);
+        button.setOnAction(e -> action.run());
+        return button;
     }
 }

--- a/src/main/java/io/molr/gui/fx/support/MolrFxSupport.java
+++ b/src/main/java/io/molr/gui/fx/support/MolrFxSupport.java
@@ -1,0 +1,16 @@
+package io.molr.gui.fx.support;
+
+import io.molr.commons.domain.Mission;
+
+import java.util.Map;
+import java.util.Set;
+
+public interface MolrFxSupport {
+
+    OngoingDebug debug(Mission mission);
+
+    OngoingDebug debug(Mission mission, Map<String, Object> parameters);
+
+    Set<Mission> executableMissions();
+
+}

--- a/src/main/java/io/molr/gui/fx/support/MolrFxSupport.java
+++ b/src/main/java/io/molr/gui/fx/support/MolrFxSupport.java
@@ -1,6 +1,10 @@
 package io.molr.gui.fx.support;
 
 import io.molr.commons.domain.Mission;
+import io.molr.mole.core.support.domain.VoidStub0;
+import io.molr.mole.core.support.domain.VoidStub1;
+import io.molr.mole.core.support.domain.VoidStub2;
+import io.molr.mole.core.support.domain.VoidStub3;
 
 import java.util.Map;
 import java.util.Set;
@@ -10,6 +14,23 @@ public interface MolrFxSupport {
     OngoingDebug debug(Mission mission);
 
     OngoingDebug debug(Mission mission, Map<String, Object> parameters);
+
+    default OngoingDebug debug(VoidStub0 stub0) {
+        return debug(stub0.mission());
+    }
+
+    default <P1> OngoingDebug debug(VoidStub1<P1> stub, P1 p1) {
+        return debug(stub.mission(), stub.parameters(p1));
+    }
+
+    default <P1, P2> OngoingDebug debug(VoidStub2<P1, P2> stub, P1 p1, P2 p2) {
+        return debug(stub.mission(), stub.parameters(p1, p2));
+    }
+
+    default <P1, P2, P3> OngoingDebug debug(VoidStub3<P1, P2, P3> stub, P1 p1, P2 p2, P3 p3) {
+        return debug(stub.mission(), stub.parameters(p1, p2, p3));
+    }
+
 
     Set<Mission> executableMissions();
 

--- a/src/main/java/io/molr/gui/fx/support/MolrFxSupportImpl.java
+++ b/src/main/java/io/molr/gui/fx/support/MolrFxSupportImpl.java
@@ -1,0 +1,51 @@
+package io.molr.gui.fx.support;
+
+import io.molr.commons.domain.Mission;
+import io.molr.commons.domain.MissionParameterDescription;
+import io.molr.gui.fx.widgets.MolrDialogs;
+import io.molr.mole.core.api.Mole;
+import javafx.scene.control.Dialog;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.Collections.emptyMap;
+import static java.util.Objects.requireNonNull;
+
+public class MolrFxSupportImpl implements MolrFxSupport {
+
+    private final Mole mole;
+
+    public MolrFxSupportImpl(Mole mole) {
+        this.mole = requireNonNull(mole, "mole must not be null");
+    }
+
+    @Override
+    public OngoingDebug debug(Mission mission) {
+        return new OngoingDebug(mole, mission, () -> parametersFor(mission));
+    }
+
+    @Override
+    public OngoingDebug debug(Mission mission, Map<String, Object> parameters) {
+        return new OngoingDebug(mole, mission, () -> Optional.of(parameters));
+    }
+
+    @Override
+    public Set<Mission> executableMissions() {
+        return mole.states().blockFirst().executableMissions();
+    }
+
+    private Optional<Map<String, Object>> parametersFor(Mission mission) {
+        MissionParameterDescription description = mole.parameterDescriptionOf(mission).block();
+
+        if (description.parameters().isEmpty()) {
+            /* This is a valid situation! There are no parameters, so no need to query them ;-)*/
+            return Optional.of(emptyMap());
+        }
+
+        Dialog<Map<String, Object>> dialog = MolrDialogs.parameterDialogFor(mission, description);
+        return dialog.showAndWait();
+    }
+}

--- a/src/main/java/io/molr/gui/fx/support/MolrFxSupportImpl.java
+++ b/src/main/java/io/molr/gui/fx/support/MolrFxSupportImpl.java
@@ -7,7 +7,6 @@ import io.molr.mole.core.api.Mole;
 import javafx.scene.control.Dialog;
 
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 

--- a/src/main/java/io/molr/gui/fx/support/OngoingDebug.java
+++ b/src/main/java/io/molr/gui/fx/support/OngoingDebug.java
@@ -1,16 +1,13 @@
 package io.molr.gui.fx.support;
 
-import com.google.common.collect.ImmutableMap;
 import io.molr.commons.domain.Mission;
 import io.molr.commons.domain.MissionHandle;
-import io.molr.commons.domain.MissionParameterDescription;
 import io.molr.gui.fx.widgets.MissionPane;
 import io.molr.mole.core.api.Mole;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import reactor.core.publisher.Mono;
 
 import java.util.Map;
 import java.util.Optional;

--- a/src/main/java/io/molr/gui/fx/support/OngoingDebug.java
+++ b/src/main/java/io/molr/gui/fx/support/OngoingDebug.java
@@ -1,0 +1,55 @@
+package io.molr.gui.fx.support;
+
+import com.google.common.collect.ImmutableMap;
+import io.molr.commons.domain.Mission;
+import io.molr.commons.domain.MissionHandle;
+import io.molr.commons.domain.MissionParameterDescription;
+import io.molr.gui.fx.widgets.MissionPane;
+import io.molr.mole.core.api.Mole;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Mono;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+
+public class OngoingDebug {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(OngoingDebug.class);
+
+    private final Mole mole;
+    private final Mission mission;
+    private final Supplier<Optional<Map<String, Object>>> params;
+
+    public OngoingDebug(Mole mole, Mission mission, Supplier<Optional<Map<String, Object>>> params) {
+        this.mole = requireNonNull(mole, "mole must not be null");
+        this.mission = requireNonNull(mission, "mission must not be null");
+        this.params = requireNonNull(params, "params must not be null");
+    }
+
+    public Optional<SimpleMissionControl> inNewStage() {
+        Optional<Map<String, Object>> parameters = params.get();
+        if (!parameters.isPresent()) {
+            LOGGER.info("Aborted by user. Mission will not be instantiated.");
+            return Optional.empty();
+        }
+        MissionHandle handle = instantiate(parameters.get());
+
+        MissionPane pane = new MissionPane(mole, mission, handle);
+        Scene scene = new Scene(pane);
+        Stage stage = new Stage();
+        stage.setScene(scene);
+        stage.show();
+
+        return Optional.of(new SimpleMissionControl(mole, handle));
+    }
+
+    private MissionHandle instantiate(Map<String, Object> pMap) {
+        return mole.instantiate(mission, pMap).block();
+    }
+}

--- a/src/main/java/io/molr/gui/fx/support/SimpleMissionControl.java
+++ b/src/main/java/io/molr/gui/fx/support/SimpleMissionControl.java
@@ -1,11 +1,7 @@
 package io.molr.gui.fx.support;
 
 import io.molr.commons.domain.MissionHandle;
-import io.molr.commons.domain.MissionState;
 import io.molr.mole.core.api.Mole;
-import reactor.core.publisher.Mono;
-
-import java.util.function.Predicate;
 
 import static io.molr.commons.domain.StrandCommand.RESUME;
 import static java.util.Objects.requireNonNull;

--- a/src/main/java/io/molr/gui/fx/support/SimpleMissionControl.java
+++ b/src/main/java/io/molr/gui/fx/support/SimpleMissionControl.java
@@ -1,0 +1,31 @@
+package io.molr.gui.fx.support;
+
+import io.molr.commons.domain.MissionHandle;
+import io.molr.commons.domain.MissionState;
+import io.molr.mole.core.api.Mole;
+import reactor.core.publisher.Mono;
+
+import java.util.function.Predicate;
+
+import static io.molr.commons.domain.StrandCommand.RESUME;
+import static java.util.Objects.requireNonNull;
+
+public class SimpleMissionControl {
+
+    private final Mole mole;
+    private final MissionHandle handle;
+
+    public SimpleMissionControl(Mole mole, MissionHandle handle) {
+        this.mole = requireNonNull(mole, "mole must not be null");
+        this.handle = requireNonNull(handle, "handle must not be null");
+    }
+
+    public SimpleMissionControl and() {
+        return this;
+    }
+
+    public void resume() {
+        mole.instructRoot(handle, RESUME);
+        /* This might still be a bit brittle. Strongly speaking, there is no concurrency guarantee ... so it might be that it is not always allowed ...*/
+    }
+}

--- a/src/main/java/io/molr/gui/fx/widgets/AvailableMissionsView.java
+++ b/src/main/java/io/molr/gui/fx/widgets/AvailableMissionsView.java
@@ -36,8 +36,6 @@ import static freetimelabs.io.reactorfx.schedulers.FxSchedulers.fxThread;
 import static java.util.Collections.emptyMap;
 import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toList;
-import static javafx.scene.control.ButtonType.APPLY;
-import static javafx.scene.control.ButtonType.CANCEL;
 import static org.minifx.workbench.domain.PerspectivePos.LEFT;
 
 @Component
@@ -156,27 +154,8 @@ public class AvailableMissionsView extends BorderPane {
             return Optional.of(emptyMap());
         }
 
-        Dialog<Map<String, Object>> dialog = parameterDialogFor(mission, description);
+        Dialog<Map<String, Object>> dialog = MolrDialogs.parameterDialogFor(mission, description);
         return dialog.showAndWait();
-    }
-
-    private Dialog<Map<String, Object>> parameterDialogFor(Mission mission, MissionParameterDescription description) {
-        ParameterEditor editor = new ParameterEditor(description.parameters());
-
-        Dialog<Map<String, Object>> dialog1 = new Dialog<>();
-        dialog1.setTitle("Parameters for mission '" + mission.name() + "'.");
-        dialog1.setHeaderText("Please check and complete the parameters for this mission.");
-
-        dialog1.getDialogPane().setContent(editor);
-        dialog1.getDialogPane().getButtonTypes().addAll(APPLY, CANCEL);
-
-        dialog1.setResultConverter(b -> {
-            if (b == APPLY) {
-                return editor.parameterValues();
-            }
-            return null;
-        });
-        return dialog1;
     }
 
     private Mission selectedMission() {

--- a/src/main/java/io/molr/gui/fx/widgets/MissionInstancesView.java
+++ b/src/main/java/io/molr/gui/fx/widgets/MissionInstancesView.java
@@ -17,9 +17,6 @@ import javafx.collections.ObservableList;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.FlowPane;
-import reactor.core.Disposable;
-import reactor.core.publisher.Flux;
-
 import org.minifx.workbench.annotations.Icon;
 import org.minifx.workbench.annotations.Name;
 import org.minifx.workbench.annotations.View;
@@ -29,11 +26,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
-
-import static freetimelabs.io.reactorfx.schedulers.FxSchedulers.fxThread;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
 
 import javax.annotation.PostConstruct;
 
+import static freetimelabs.io.reactorfx.schedulers.FxSchedulers.fxThread;
 import static org.minifx.workbench.domain.PerspectivePos.LEFT;
 
 @Component

--- a/src/main/java/io/molr/gui/fx/widgets/MissionPane.java
+++ b/src/main/java/io/molr/gui/fx/widgets/MissionPane.java
@@ -4,7 +4,6 @@
 
 package io.molr.gui.fx.widgets;
 
-import com.google.common.net.MediaType;
 import io.molr.commons.domain.*;
 import io.molr.gui.fx.util.FormattedButton;
 import io.molr.gui.fx.widgets.breakpoints.BreakpointCell;
@@ -27,18 +26,11 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.VBox;
 import javafx.util.Callback;
-import reactor.core.publisher.Flux;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
 
-import javax.annotation.PostConstruct;
 import java.util.*;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 

--- a/src/main/java/io/molr/gui/fx/widgets/MissionPane.java
+++ b/src/main/java/io/molr/gui/fx/widgets/MissionPane.java
@@ -4,6 +4,7 @@
 
 package io.molr.gui.fx.widgets;
 
+import com.google.common.net.MediaType;
 import io.molr.commons.domain.*;
 import io.molr.gui.fx.util.FormattedButton;
 import io.molr.gui.fx.widgets.breakpoints.BreakpointCell;
@@ -51,7 +52,6 @@ public class MissionPane extends BorderPane {
     private static final Logger LOGGER = LoggerFactory.getLogger(MissionPane.class);
 
     private final Mission mission;
-    private final MissionParameterDescription description;
     private final Map<String, ExecutableLine> lines = new HashMap<>();
     private List<EventHandler> eventsList = new ArrayList<EventHandler>();
 
@@ -72,17 +72,15 @@ public class MissionPane extends BorderPane {
 
     private final Mole mole;
 
-    public MissionPane(Mole mole, Mission mission, MissionParameterDescription description) {
+    public MissionPane(Mole mole, Mission mission) {
         this.mole = requireNonNull(mole, "mole must not be null");
         this.mission = requireNonNull(mission, "mission must not be null");
-        this.description = requireNonNull(description, "description must not be null");
         init();
     }
 
-    public MissionPane(Mole mole, Mission mission, MissionParameterDescription description, MissionHandle missionHandle) {
+    public MissionPane(Mole mole, Mission mission, MissionHandle missionHandle) {
         this.mole = requireNonNull(mole, "mole must not be null");
         this.mission = requireNonNull(mission, "mission must not be null");
-        this.description = requireNonNull(description, "description must not be null");
         this.missionHandle.set(requireNonNull(missionHandle, "missionInstance must not be null"));
         init();
     }
@@ -143,6 +141,7 @@ public class MissionPane extends BorderPane {
     }
 
     private void configureInstantiable() {
+        MissionParameterDescription description = mole.parameterDescriptionOf(mission).block();
         ParameterEditor parameterEditor = new ParameterEditor(description.parameters());
         instanceInfo.getChildren().add(parameterEditor);
 

--- a/src/main/java/io/molr/gui/fx/widgets/MissionPane.java
+++ b/src/main/java/io/molr/gui/fx/widgets/MissionPane.java
@@ -60,7 +60,6 @@ public class MissionPane extends BorderPane {
     private final Mission mission;
     private final MissionParameterDescription description;
     private final Map<String, ExecutableLine> lines = new HashMap<>();
-    private final ScheduledExecutorService scheduled = Executors.newSingleThreadScheduledExecutor();
     private List<EventHandler> eventsList = new ArrayList<EventHandler>();
 
     private TreeTableView<ExecutableLine> blockTableView;
@@ -73,7 +72,6 @@ public class MissionPane extends BorderPane {
     private final AtomicReference<MissionHandle> missionHandle = new AtomicReference<>();
 
     private final SimpleObjectProperty<MissionState> lastState = new SimpleObjectProperty<>();
-    private final SimpleObjectProperty<MissionRepresentation> lastRepresentation = new SimpleObjectProperty<>();
 
     private final Map<StrandCommand, FormattedButton> commandButtons = new EnumMap<StrandCommand, FormattedButton>(StrandCommand.class);
     

--- a/src/main/java/io/molr/gui/fx/widgets/MissionView.java
+++ b/src/main/java/io/molr/gui/fx/widgets/MissionView.java
@@ -10,6 +10,7 @@ import io.molr.commons.domain.MissionParameterDescription;
 import io.molr.gui.fx.commands.ViewMission;
 import io.molr.gui.fx.commands.ViewMissionInstance;
 import io.molr.gui.fx.perspectives.MissionsPerspective;
+import io.molr.mole.core.api.Mole;
 import javafx.application.Platform;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
@@ -17,7 +18,10 @@ import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.BorderPane;
 import org.minifx.workbench.annotations.View;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Lookup;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Scope;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -27,12 +31,15 @@ import static org.minifx.workbench.domain.PerspectivePos.CENTER;
 @Component
 public abstract class MissionView extends BorderPane {
 
+    @Autowired
+    private Mole mole;
+
     private final TabPane tabPane;
 
     public MissionView() {
         tabPane = new TabPane();
         setCenter(tabPane);
-       // addKeyboardShortcuts();
+        // addKeyboardShortcuts();
 
     }
 
@@ -44,20 +51,15 @@ public abstract class MissionView extends BorderPane {
         });
     }
 
-    private void addKeyboardShortcuts(){
+    private void addKeyboardShortcuts() {
         this.addEventFilter(KeyEvent.KEY_PRESSED, e -> {
-            if (e.getCode() == KeyCode.F2){
+            if (e.getCode() == KeyCode.F2) {
                 System.out.println("F2");
-            }
-            else
-            {
+            } else {
                 System.out.println(e.getCode() + " was pressed");
             }
         });
     }
-
-
-
 
 
     @EventListener
@@ -74,9 +76,12 @@ public abstract class MissionView extends BorderPane {
         tabPane.getSelectionModel().select(tab);
     }
 
-    @Lookup
-    public abstract MissionPane missionPane(Mission mission, MissionParameterDescription description);
 
-    @Lookup
-    public abstract MissionPane missionPane(Mission mission, MissionParameterDescription description, MissionHandle missionHandle);
+    private MissionPane missionPane(Mission mission, MissionParameterDescription description) {
+        return new MissionPane(mole, mission, description);
+    }
+
+    private MissionPane missionPane(Mission mission, MissionParameterDescription description, MissionHandle missionHandle) {
+        return new MissionPane(mole, mission, description, missionHandle);
+    }
 }

--- a/src/main/java/io/molr/gui/fx/widgets/MissionView.java
+++ b/src/main/java/io/molr/gui/fx/widgets/MissionView.java
@@ -19,9 +19,6 @@ import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.BorderPane;
 import org.minifx.workbench.annotations.View;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Lookup;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Scope;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 

--- a/src/main/java/io/molr/gui/fx/widgets/MissionView.java
+++ b/src/main/java/io/molr/gui/fx/widgets/MissionView.java
@@ -78,10 +78,10 @@ public abstract class MissionView extends BorderPane {
 
 
     private MissionPane missionPane(Mission mission, MissionParameterDescription description) {
-        return new MissionPane(mole, mission, description);
+        return new MissionPane(mole, mission);
     }
 
     private MissionPane missionPane(Mission mission, MissionParameterDescription description, MissionHandle missionHandle) {
-        return new MissionPane(mole, mission, description, missionHandle);
+        return new MissionPane(mole, mission, missionHandle);
     }
 }

--- a/src/main/java/io/molr/gui/fx/widgets/MolrDialogs.java
+++ b/src/main/java/io/molr/gui/fx/widgets/MolrDialogs.java
@@ -1,0 +1,39 @@
+package io.molr.gui.fx.widgets;
+
+import io.molr.commons.domain.Mission;
+import io.molr.commons.domain.MissionParameterDescription;
+import javafx.scene.control.Dialog;
+
+import java.util.Map;
+
+import static javafx.scene.control.ButtonType.APPLY;
+import static javafx.scene.control.ButtonType.CANCEL;
+
+/**
+ * Contains static utility methods for mol related dialogs
+ */
+public final class MolrDialogs {
+
+    private MolrDialogs() {
+        throw new UnsupportedOperationException("Only static methods");
+    }
+
+    public static final Dialog<Map<String, Object>> parameterDialogFor(Mission mission, MissionParameterDescription description) {
+        ParameterEditor editor = new ParameterEditor(description.parameters());
+
+        Dialog<Map<String, Object>> dialog1 = new Dialog<>();
+        dialog1.setTitle("Parameters for mission '" + mission.name() + "'.");
+        dialog1.setHeaderText("Please check and complete the parameters for this mission.");
+
+        dialog1.getDialogPane().setContent(editor);
+        dialog1.getDialogPane().getButtonTypes().addAll(APPLY, CANCEL);
+
+        dialog1.setResultConverter(b -> {
+            if (b == APPLY) {
+                return editor.parameterValues();
+            }
+            return null;
+        });
+        return dialog1;
+    }
+}

--- a/src/main/java/io/molr/gui/fx/widgets/breakpoints/BreakpointCell.java
+++ b/src/main/java/io/molr/gui/fx/widgets/breakpoints/BreakpointCell.java
@@ -11,11 +11,10 @@ import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.TreeTableCell;
 import javafx.scene.control.TreeTableRow;
-
-import java.text.MessageFormat;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.text.MessageFormat;
 
 public class BreakpointCell extends TreeTableCell<ExecutableLine, BreakpointCellData>{
     

--- a/src/main/java/io/molr/gui/fx/widgets/breakpoints/BreakpointCellData.java
+++ b/src/main/java/io/molr/gui/fx/widgets/breakpoints/BreakpointCellData.java
@@ -1,9 +1,9 @@
 package io.molr.gui.fx.widgets.breakpoints;
 
+import io.molr.commons.domain.BlockCommand;
+
 import java.util.HashSet;
 import java.util.Set;
-
-import io.molr.commons.domain.BlockCommand;
 
 public class BreakpointCellData {
     


### PR DESCRIPTION
# MolrFxSupport

This is a proposal, inspired by recent discussions

The principle idea is to provide some easily accessible GUI components and UI-processes to handle molr missions from other fx applications. As a first proposal, the central entry point would be the class MolrFxSupport.

This class can be accessed in 2 ways:
* By importing the MolrFxSupportConfiguration into the spring configuration of the UI, which then will pick up the mole by itself (this is the recommended approach)
* For GUIs which are not primarily spring based, there is a factory (MolrFxSupportFactory) which can load the application context for you and pick up the m ole from the additional configuration classes provided as parameters.

Having an instance, it can be used e.g. like:
```
Mission m;
support.debug(m).inNewStage();
```
... this would open a new window, with the given mission.

This method chain returns also an `Optional<SimpleMissionControl>`, which is intended to allow convenient programmatically control over the mission. At the moment, the only supported command is `resume`:
```
Mission m;
support.debug(m).inNewStage().ifPresent(SimpleMissionControl::resume);
```
this would open a window and immediately run the mission.

NOTE: All this is a first proof of concept. The idea is to put more and more functionality into this (e.g. options like cleanup on close or similar), or running multiple missions....

# Mission stubs

A little additional sugar are the reactivation of mission stubs: This allows to e.g. define mission stubs as constants and then later use these stubs to run the missions. This allows typed checked parameters.

E.g. a stub with three parameters could be defined as:
```
private static VoidStub3<String, Integer, Integer> PARAMETRIZED_MISSION = stub("parametrized mission") //
            .withParameters(aString("aMessage"), anInteger("iterations"), anInteger("sleepMillis"));
```

It can then be used with the gui support class as:
```
support.debug(PARAMETRIZED_MISSION, "Hello World", 3, 200).inNewStage();
```

A demo of all this functionality can be found in the following classes:
* MolrFxSupportDemoApplication
* MolrFxSupportMinimalSpringDemo [note: for some reason I did not get this one to run without the minifx launcher ... despite it *should*
